### PR TITLE
client_secret is optional in all grant types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ Provides an OAuth2 plugin (middleware) for [Guzzle](http://guzzlephp.org/).
 
 Version 3.x (on the `master` branch) is intended for Guzzle 6:
 ```json
-        "sainsburys/guzzle-oauth2-plugin": "~3.0"
+        "sainsburys/guzzle-oauth2-plugin": "^3.0"
 ```
 
 Version 2.x (on the `release/2.0` branch) is intended for Guzzle 5:
 ```json
-        "sainsburys/guzzle-oauth2-plugin": "~2.0"
+        "sainsburys/guzzle-oauth2-plugin": "^2.0"
 ```
 
 Version 1.x (on the `release/1.0` branch) is intended for Guzzle 3 [Unmaintained]:
 ```json
-        "sainsburys/guzzle-oauth2-plugin": "~1.0"
+        "sainsburys/guzzle-oauth2-plugin": "^1.0"
 ```
 
 ## Features
@@ -36,16 +36,13 @@ First make sure you have all the dependencies in place by running `composer inst
 
 ## Example
 ```php
+use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use Sainsburys\Guzzle\Oauth2\GrantType\RefreshToken;
 use Sainsburys\Guzzle\Oauth2\GrantType\PasswordCredentials;
 use Sainsburys\Guzzle\Oauth2\Middleware\OAuthMiddleware;
 
-$base_uri = 'https://example.com';
-
-$handlerStack = HandlerStack::create();
-$client = new Client(['handler'=> $handlerStack, 'base_uri' => $base_uri, 'auth' => 'oauth2']);
-
+$baseUri = 'https://example.com';
 $config = [
     PasswordCredentials::CONFIG_USERNAME => 'test@example.com',
     PasswordCredentials::CONFIG_PASSWORD => 'test password',
@@ -54,18 +51,89 @@ $config = [
     'scope' => 'administration',
 ];
 
-$token = new PasswordCredentials($client, $config);
-$refreshToken = new RefreshToken($client, $config);
-$middleware = new OAuthMiddleware($client, $token, $refreshToken);
+$oauthClient = new Client(['base_uri' => $baseUri]);
+$grantType = new PasswordCredentials($oauthClient, $config);
+$refreshToken = new RefreshToken($oauthClient, $config);
+$middleware = new OAuthMiddleware($oauthClient, $grantType, $refreshToken);
 
+$handlerStack = HandlerStack::create();
 $handlerStack->push($middleware->onBefore());
 $handlerStack->push($middleware->onFailure(5));
 
-$response = $client->get('/api/user/me');
+$client = new Client(['handler'=> $handlerStack, 'base_uri' => $baseUri, 'auth' => 'oauth2']);
 
-print_r($response->json());
+$response = $client->request('GET', '/api/user/me');
 
 // Use $middleware->getAccessToken(); and $middleware->getRefreshToken() to get tokens
 // that can be persisted for subsequent requests.
+```
 
+## Example using Symfony DI config
+
+```xml
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="acme.base_uri">https://example.com</parameter>
+        <parameter key="acme.oauth.config" type="collection">
+            <parameter key="username">test@example.com</parameter>
+            <parameter key="password">test password</parameter>
+            <parameter key="client_id">test-client</parameter>
+            <parameter key="token_url">/oauth/token</parameter>
+        </parameter>
+    </parameters>
+
+    <services>
+        <service id="acme.oauth.guzzle.client" class="GuzzleHttp\Client" public="false">
+            <argument type="collection">
+                <argument key="base_uri">%acme.base_uri%</argument>
+            </argument>
+        </service>
+
+        <service id="acme.oauth.grant_type" class="Sainsburys\Guzzle\Oauth2\GrantType\PasswordCredentials" public="false">
+            <argument type="service" id="acme.oauth.guzzle.client"/>
+            <argument>%acme.oauth.config%</argument>
+        </service>
+
+        <service id="acme.oauth.refresh_token" class="Sainsburys\Guzzle\Oauth2\GrantType\RefreshToken" public="false">
+            <argument type="service" id="acme.oauth.guzzle.client"/>
+            <argument>%acme.oauth.config%</argument>
+        </service>
+
+        <service id="acme.oauth.middleware" class="Sainsburys\Guzzle\Oauth2\Middleware\OAuthMiddleware" public="false">
+            <argument type="service" id="acme.oauth.guzzle.client"/>
+            <argument type="service" id="acme.oauth.grant_type"/>
+            <argument type="service" id="acme.oauth.refresh_token"/>
+        </service>
+
+        <service id="acme.guzzle.handler" class="GuzzleHttp\HandlerStack" public="false">
+            <factory class="GuzzleHttp\HandlerStack" method="create"/>
+            <call method="push">
+                <argument type="service">
+                    <service class="Closure">
+                        <factory service="acme.oauth.middleware" method="onBefore"/>
+                    </service>
+                </argument>
+            </call>
+            <call method="push">
+                <argument type="service">
+                    <service class="Closure">
+                        <factory service="acme.oauth.middleware" method="onFailure"/>
+                        <argument>5</argument>
+                    </service>
+                </argument>
+            </call>
+        </service>
+
+        <service id="acme.guzzle.client" class="GuzzleHttp\Client">
+            <argument type="collection">
+                <argument key="handler" type="service" id="acme.guzzle.handler" />
+                <argument key="base_uri">%acme.base_uri%</argument>
+                <argument key="auth">oauth2</argument>
+            </argument>
+        </service>
+    </services>
+</container>
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,11 @@
 {
     "name": "sainsburys/guzzle-oauth2-plugin",
-    "description": "An OAuth2 plugin (subscriber) for Guzzle",
+    "description": "An OAuth2 middleware for Guzzle",
     "license": "MIT",
     "require": {
-        "guzzlehttp/guzzle": "~6.0",
-        "firebase/php-jwt": "~3.0|~4.0"
+        "php": ">=5.6",
+        "guzzlehttp/guzzle": "^6.0",
+        "firebase/php-jwt": "^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {
@@ -12,7 +13,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5"
+        "phpunit/phpunit": "^4.8"
     },
     "autoload-dev": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit
-    backupGlobals               = "false"
-    backupStaticAttributes      = "false"
-    colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    syntaxCheck                 = "true"
-    bootstrap                   = "tests/bootstrap.php">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+    backupGlobals = "false"
+    colors        = "true"
+    bootstrap     = "vendor/autoload.php"
+>
 
     <testsuites>
         <testsuite name="Plugin tests">

--- a/src/GrantType/GrantTypeBase.php
+++ b/src/GrantType/GrantTypeBase.php
@@ -72,7 +72,6 @@ abstract class GrantTypeBase implements GrantTypeInterface
     {
         return [
             self::CONFIG_CLIENT_ID => '',
-            self::CONFIG_CLIENT_SECRET => '',
         ];
     }
 
@@ -120,7 +119,10 @@ abstract class GrantTypeBase implements GrantTypeInterface
         $requestOptions = [];
 
         if ($this->config[self::CONFIG_AUTH_LOCATION] !== RequestOptions::BODY) {
-            $requestOptions[RequestOptions::AUTH] = [$this->config[self::CONFIG_CLIENT_ID], $this->config[self::CONFIG_CLIENT_SECRET]];
+            $requestOptions[RequestOptions::AUTH] = [
+                $this->config[self::CONFIG_CLIENT_ID],
+                isset($this->config[self::CONFIG_CLIENT_SECRET]) ? $this->config[self::CONFIG_CLIENT_SECRET] : '',
+            ];
             unset($body[self::CONFIG_CLIENT_ID], $body[self::CONFIG_CLIENT_SECRET]);
         }
 

--- a/tests/GrantType/AuthorizationCodeTest.php
+++ b/tests/GrantType/AuthorizationCodeTest.php
@@ -18,7 +18,6 @@ class AuthorizationCodeTest extends TestBase
         $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "code"');
         new AuthorizationCode($this->createClient(), [
             'client_id' => 'testClient',
-            'client_secret' => 'clientSecret'
         ]);
     }
 }

--- a/tests/GrantType/AuthorizationCodeTest.php
+++ b/tests/GrantType/AuthorizationCodeTest.php
@@ -9,13 +9,13 @@ class AuthorizationCodeTest extends TestBase
 {
     public function testMissingParentConfigException()
     {
-        $this->setExpectedException('\\InvalidArgumentException', 'The config is missing the following key: "client_id"');
+        $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "client_id"');
         new AuthorizationCode($this->createClient());
     }
 
     public function testMissingConfigException()
     {
-        $this->setExpectedException('\\InvalidArgumentException', 'The config is missing the following key: "code"');
+        $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "code"');
         new AuthorizationCode($this->createClient(), [
             'client_id' => 'testClient',
             'client_secret' => 'clientSecret'

--- a/tests/GrantType/JwtBearerTest.php
+++ b/tests/GrantType/JwtBearerTest.php
@@ -10,13 +10,13 @@ class JwtBearerTest extends TestBase
 {
     public function testMissingParentConfigException()
     {
-        $this->setExpectedException('\\InvalidArgumentException', 'The config is missing the following key: "client_id"');
+        $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "client_id"');
         new JwtBearer($this->createClient());
     }
 
     public function testMissingConfigException()
     {
-        $this->setExpectedException('\\InvalidArgumentException', 'The config is missing the following key: "private_key"');
+        $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "private_key"');
         new JwtBearer($this->createClient(), [
             'client_id' => 'testClient',
             'client_secret' => 'clientSecret'
@@ -25,7 +25,7 @@ class JwtBearerTest extends TestBase
 
     public function testPrivateKeyNotSplFileObject()
     {
-        $this->setExpectedException('\\InvalidArgumentException', 'private_key needs to be instance of SplFileObject');
+        $this->setExpectedException(\InvalidArgumentException::class, 'private_key needs to be instance of SplFileObject');
         new JwtBearer($this->createClient(), [
             'client_id' => 'testClient',
             'client_secret' => 'clientSecret',

--- a/tests/GrantType/JwtBearerTest.php
+++ b/tests/GrantType/JwtBearerTest.php
@@ -19,7 +19,6 @@ class JwtBearerTest extends TestBase
         $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "private_key"');
         new JwtBearer($this->createClient(), [
             'client_id' => 'testClient',
-            'client_secret' => 'clientSecret'
         ]);
     }
 
@@ -28,7 +27,6 @@ class JwtBearerTest extends TestBase
         $this->setExpectedException(\InvalidArgumentException::class, 'private_key needs to be instance of SplFileObject');
         new JwtBearer($this->createClient(), [
             'client_id' => 'testClient',
-            'client_secret' => 'clientSecret',
             'private_key' => 'INVALID'
         ]);
     }
@@ -37,7 +35,6 @@ class JwtBearerTest extends TestBase
     {
         $grantType = new JwtBearer($this->createClient(), [
             'client_id' => 'testClient',
-            'client_secret' => 'clientSecret',
             'private_key' => new SplFileObject(__DIR__ . '/../private.key')
         ]);
         $token = $grantType->getToken();

--- a/tests/GrantType/PasswordCredentialsTest.php
+++ b/tests/GrantType/PasswordCredentialsTest.php
@@ -9,13 +9,13 @@ class PasswordCredentialsTest extends TestBase
 {
     public function testMissingParentConfigException()
     {
-        $this->setExpectedException('\\InvalidArgumentException', 'The config is missing the following key: "client_id"');
+        $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "client_id"');
         new PasswordCredentials($this->createClient());
     }
 
     public function testMissingUsernameConfigException()
     {
-        $this->setExpectedException('\\InvalidArgumentException', 'The config is missing the following key: "username"');
+        $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "username"');
         new PasswordCredentials($this->createClient(), [
             'client_id' => 'testClient',
             'client_secret' => 'clientSecret',
@@ -24,7 +24,7 @@ class PasswordCredentialsTest extends TestBase
 
     public function testMissingPasswordConfigException()
     {
-        $this->setExpectedException('\\InvalidArgumentException', 'The config is missing the following key: "password"');
+        $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "password"');
         new PasswordCredentials($this->createClient(), [
             'client_id' => 'testClient',
             'client_secret' => 'clientSecret',

--- a/tests/GrantType/PasswordCredentialsTest.php
+++ b/tests/GrantType/PasswordCredentialsTest.php
@@ -18,7 +18,6 @@ class PasswordCredentialsTest extends TestBase
         $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "username"');
         new PasswordCredentials($this->createClient(), [
             'client_id' => 'testClient',
-            'client_secret' => 'clientSecret',
         ]);
     }
 
@@ -27,7 +26,6 @@ class PasswordCredentialsTest extends TestBase
         $this->setExpectedException(\InvalidArgumentException::class, 'The config is missing the following key: "password"');
         new PasswordCredentials($this->createClient(), [
             'client_id' => 'testClient',
-            'client_secret' => 'clientSecret',
             'username' => 'validUsername',
         ]);
     }
@@ -36,7 +34,6 @@ class PasswordCredentialsTest extends TestBase
     {
         $grantType = new PasswordCredentials($this->createClient(), [
             'client_id' => 'testClient',
-            'client_secret' => 'clientSecret',
             'username' => 'validUsername',
             'password' => 'validPassword',
         ]);

--- a/tests/GrantType/RefreshTokenTest.php
+++ b/tests/GrantType/RefreshTokenTest.php
@@ -13,7 +13,7 @@ class RefreshTokenTest extends TestBase
             'client_id' => 'test',
             'client_secret' => 'clientSecret',
         ]);
-        $this->setExpectedException('\\RuntimeException');
+        $this->setExpectedException(\RuntimeException::class);
         $grant->getToken();
     }
 }

--- a/tests/GrantType/RefreshTokenTest.php
+++ b/tests/GrantType/RefreshTokenTest.php
@@ -11,7 +11,6 @@ class RefreshTokenTest extends TestBase
     {
         $grant = new RefreshToken($this->createClient(), [
             'client_id' => 'test',
-            'client_secret' => 'clientSecret',
         ]);
         $this->setExpectedException(\RuntimeException::class);
         $grant->getToken();

--- a/tests/Middleware/OAuthMiddlewareTest.php
+++ b/tests/Middleware/OAuthMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sainsburys\Guzzle\Oauth2\Tests\GrantType;
+namespace Sainsburys\Guzzle\Oauth2\Tests\Middleware;
 
 use Sainsburys\Guzzle\Oauth2\AccessToken;
 use Sainsburys\Guzzle\Oauth2\GrantType\ClientCredentials;
@@ -9,7 +9,6 @@ use Sainsburys\Guzzle\Oauth2\Middleware\OAuthMiddleware;
 use Sainsburys\Guzzle\Oauth2\Tests\MockOAuth2Server;
 use Sainsburys\Guzzle\Oauth2\Tests\MockOAuthMiddleware;
 use Sainsburys\Guzzle\Oauth2\Tests\TestBase;
-use GuzzleHttp\HandlerStack;
 use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\ResponseInterface;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,0 @@
-<?php
-/**
- * @file
- * A script containing any set-up steps required for PHPUnit testing.
- */
-
-require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
> The client ID is considered public information, and is used to build login URLs, or included in Javascript source code on a page. The client secret must be kept confidential. If a deployed app cannot keep the secret confidential, such as single-page Javascript apps or native apps, then the secret is not used, and ideally the service shouldn't issue a secret to these types of apps in the first place.

https://aaronparecki.com/oauth-2-simplified/

When there is no client_secret you also must not send one (in our case pivotal cloudfoundry oauth). But the current validation makes this impossible.