### PR TITLE
Missing sprintf

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -107,7 +107,7 @@ class AccessToken
     public function setRefreshToken(AccessToken $refreshToken)
     {
         if ($refreshToken->getType() != 'refresh_token') {
-            throw new InvalidArgumentException('Expected AccessToken to be "refresh_token" type, got "%s"', $refreshToken->getType());
+            throw new InvalidArgumentException(sprintf('Expected AccessToken to be "refresh_token" type, got "%s"', $refreshToken->getType()));
         }
 
         $this->refreshToken = $refreshToken;


### PR DESCRIPTION
There is a wrong number of parameters for InvalidArgumentException. I suspect that sprintf is intended there. So here it is.