### PR TITLE
Fixes empty 'Authorization' Header

### DIFF
--- a/src/Middleware/OAuthMiddleware.php
+++ b/src/Middleware/OAuthMiddleware.php
@@ -65,7 +65,7 @@ class OAuthMiddleware
                 ) {
                     $token = $this->getAccessToken();
                     if ($token !== null) {
-                        return $handler($request->withAddedHeader('Authorization', 'Bearer '.$token->getToken()), $options);
+                        return $handler($request->withHeader('Authorization', 'Bearer '.$token->getToken()), $options);
                     }
                 }
 


### PR DESCRIPTION
We experienced an issue where requests were send with only `Bearer` in `Authorization` header but without the real token.

This PR fixes this problem and ensures, that always the token of the middleware is used.