### PR TITLE
PHP 8.4 compatibility fixes

### DIFF
--- a/src/Middleware/OAuthMiddleware.php
+++ b/src/Middleware/OAuthMiddleware.php
@@ -42,8 +42,8 @@ class OAuthMiddleware
      */
     public function __construct(
         ClientInterface $client,
-        GrantTypeInterface $grantType = null,
-        RefreshTokenGrantTypeInterface $refreshTokenGrantType = null
+        ?GrantTypeInterface $grantType = null,
+        ?RefreshTokenGrantTypeInterface $refreshTokenGrantType = null
     ) {
         $this->client = $client;
         $this->grantType = $grantType;

--- a/tests/MockOAuthMiddleware.php
+++ b/tests/MockOAuthMiddleware.php
@@ -36,9 +36,9 @@ class MockOAuthMiddleware extends OAuthMiddleware
      */
     public function __construct(
         ClientInterface $client,
-        GrantTypeInterface $grantType = null,
-        RefreshTokenGrantTypeInterface $refreshTokenGrantType = null,
-        array $options = []
+        ?GrantTypeInterface $grantType = null,
+        ?RefreshTokenGrantTypeInterface $refreshTokenGrantType = null,
+        ?array $options = []
     ) {
         parent::__construct($client, $grantType, $refreshTokenGrantType);
 


### PR DESCRIPTION
Fixes PHP warning "Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead."